### PR TITLE
Fix BIM Blog button browser launch

### DIFF
--- a/VALTRIA Tools.tab/QA.panel/BIM Blog.pushbutton/script.py
+++ b/VALTRIA Tools.tab/QA.panel/BIM Blog.pushbutton/script.py
@@ -11,7 +11,12 @@ URL = "https://valtria.com/en/blog/bim-para-salas-limpias/"
 logger = script.get_logger()
 
 try:
-    webbrowser.open(URL, new=2)
+    try:
+        webbrowser.open_new_tab(URL)
+    except TypeError:
+        # IronPython puede llamar a la versión integrada de ``open`` por error.
+        # Volvemos a intentar con ``webbrowser.open`` usando argumentos posicionales.
+        webbrowser.open(URL, 2)
     logger.info("Abriendo el artículo: %s", URL)
 except Exception as error:  # pragma: no cover - entorno de Revit
     logger.error("No se pudo abrir el navegador: %s", error)


### PR DESCRIPTION
## Summary
- use webbrowser.open_new_tab to launch the BIM blog article
- add a fallback that retries with positional arguments to avoid IronPython keyword issues

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c56509108323bd3bfaa670e89345